### PR TITLE
Add wagtail viewset

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,39 @@ class CountryQuerySet(Queryish):
 ```
 
 Subclasses will also typically override the method `run_count`, which returns the number of records in the queryset accounting for any filtering and slicing. If this is not overridden, the default implementation will call `run_query` and count the results.
+
+## Wagtail
+
+_queryish_ includes a [Custom ViewSet](https://docs.wagtail.org/en/stable/reference/viewsets.html#viewset) for wagtail. This view includes an inspect view enabled by default and a list view. (queryish.wagtail_modelview.QueryishModelViewSet)
+
+In addition to all the [Wagtail ViewSet](https://docs.wagtail.org/en/stable/reference/viewsets.html#viewset) options the following options are available.
+
+* model - Queryish APIModel (required)
+* name - Default url prefix and namespace (required)
+* menu_label - Label in wagtail menu (required)
+* list_display - fields to display in the list view
+* inspect_view_fields - fields to show in inspect view (default all model fields)
+* inspect_view_fields_exclude - fields to exclude from the inspect view
+
+Example:
+
+```python
+from queryish.wagtail_modelview import QueryishModelViewSet
+
+class PartyModelViewSet(QueryishModelViewSet):
+    model = Party
+    icon = "table"
+    inspect_view_enabled = True
+    add_to_admin_menu = True
+    name='Party'
+    menu_label='Party'
+
+    list_display = ["id", "name", "start_date", "end_date", "location", "country_code"]
+
+    inspect_view_fields_exclude = ["id"]
+
+@hooks.register("register_admin_viewset")
+def register_viewset():
+    return PartyModelViewSet()
+
+```

--- a/queryish/__init__.py
+++ b/queryish/__init__.py
@@ -171,7 +171,51 @@ class VirtualModelOptions:
         self.fields = fields
         self.verbose_name = verbose_name
         self.verbose_name_plural = verbose_name_plural
+        self.app_label = 'QueryishVirtualApp'
+        self.db_table = 'QueryishVirtualTable'
+        self.hidden_fields = []
+        self.private_fields = []
+        self.concrete_fields =  self.fields
+        self.many_to_many = []
+        
 
+    
+    def get_fields(self, include_parents=True, include_hidden=False):
+        """
+        Return a list of fields associated to the model. By default, include
+        forward and reverse fields, fields derived from inheritance, but not
+        hidden fields. The returned fields can be changed using the parameters:
+
+        - include_parents: include fields derived from inheritance
+        - include_hidden:  include fields that have a related_name that
+                           starts with a "+"
+        """
+        
+        fields = []
+        
+        for field in self.fields:
+            fields.append(self.get_field(field))
+        return tuple(fields)
+        
+    def get_field(self,field_name):
+        try:
+            from django.db import models
+            from django.core.exceptions import FieldDoesNotExist
+            
+            if field_name in self.fields:
+                field = models.CharField()
+                field.name = field_name
+                field.attname = field_name
+                field.verbose_name = field_name
+                field.concrete = True
+                return field
+            raise FieldDoesNotExist('No "' + field_name+'" found')
+        except ImportError:
+            raise ImportError("django must be installed to use get_field")
+
+    
+    def get_parent_list(self):
+        return []
 
 class VirtualModelMetaclass(type):
     def __new__(cls, name, bases, attrs):

--- a/queryish/wagtail_modelview.py
+++ b/queryish/wagtail_modelview.py
@@ -1,0 +1,101 @@
+try:
+    from wagtail.admin.viewsets.base import ViewSet
+    from django.urls import path
+    from wagtail.permission_policies import ModelPermissionPolicy
+    from wagtail.admin.views.generic.models import IndexView, InspectView
+except ImportError:
+    raise ImportError("Wagtail must be installed to use QueryishModelViewSet")
+
+
+class ViewModelPermissionPolicy(ModelPermissionPolicy):
+    def user_has_permission(self, *args, **kwargs):
+        return True
+
+    def users_with_any_permission(self, actions):
+        return True
+
+    def user_has_any_permission(self, user, *args, **kwargs):
+        return True
+
+
+class QueryishModelViewSet(ViewSet):
+    model = None
+    
+    inspect_view_enabled = True
+    list_display = []
+
+    def get_list_display(self):
+        if len(self.list_display) == 0:
+            return self.model._meta.fields
+        else:
+            return self.list_display
+
+    list_filter = []
+    inspect_view_fields = []
+    inspect_view_fields_exclude = []
+
+    def get_inspect_view_kwargs(self, **kwargs):
+        return {
+            "template_name": "wagtailadmin/generic/inspect.html",
+            "fields": self.inspect_view_fields,
+            "fields_exclude": self.inspect_view_fields_exclude,
+            **kwargs,
+        }
+
+    def index(self, request):
+        return self.construct_view(IndexView, **self.get_index_view_kwargs())(request)
+    
+    @property
+    def inspect_view(self):
+        return self.construct_view(
+            InspectView, **self.get_inspect_view_kwargs()
+        )
+
+
+    def get_common_view_kwargs(self, **kwargs):
+        view_kwargs = super().get_common_view_kwargs(
+            **{
+                "model": self.model,
+                "permission_policy": ViewModelPermissionPolicy,
+                "index_url_name": self.get_url_name("index"),
+                "history_url_name": self.get_url_name("history"),
+                "usage_url_name": self.get_url_name("usage"),
+                "header_icon": self.icon,
+                "_show_breadcrumbs": True,
+                **kwargs,
+            }
+        )
+
+        if self.inspect_view_enabled:
+            view_kwargs["inspect_url_name"] = self.get_url_name("inspect")
+        return view_kwargs
+
+    def get_index_view_kwargs(self, **kwargs):
+        view_kwargs = {
+            "template_name": "wagtailadmin/generic/index.html",
+            "results_template_name": "wagtailadmin/generic/index_results.html",
+            "list_display": self.get_list_display(),
+            "list_filter": self.list_filter,
+            "list_export": [],
+            "export_headings": {},
+            "export_filename": "file",
+            "filterset_class": None,
+            "search_fields": [],
+            "search_backend_name": "default",
+            "paginate_by": 20,
+            **kwargs,
+        }
+        return view_kwargs
+
+    def get_urlpatterns(self):
+        url_patterns =  [
+            path("", self.index, name="index"),
+            
+        ]
+        
+        if self.inspect_view_enabled:
+            url_patterns.append(
+                path("inspect/<str:pk>/", self.inspect_view, name="inspect")
+            )
+        return url_patterns
+ 


### PR DESCRIPTION
Add support for wagtail QueryishModelViewSet and model get_field and get_fields methods for additional compatibility.

```python
from queryish.wagtail_modelview import QueryishModelViewSet

class PartyModelViewSet(QueryishModelViewSet):
    model = Party
    icon = "table"
    inspect_view_enabled = True
    add_to_admin_menu = True
    name='Party'
    menu_label='Party'

    list_display = ["id", "name", "start_date", "end_date", "location", "country_code"]

    inspect_view_fields_exclude = ["id"]

@hooks.register("register_admin_viewset")
def register_viewset():
    return PartyModelViewSet()
```